### PR TITLE
add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+dill==0.3.1.1
+nltk==3.4.5
+numpy==1.17.4
+progress==1.5
+six==1.13.0
+torch==1.3.1


### PR DESCRIPTION
To figure out what should be in this file, I ran these commands from the repository root (assumes you have [`mkvirtualenv`](https://virtualenvwrapper.readthedocs.io/en/latest/install.html) installed):
```bash
$ mkvirtualenv project_rc --python $(which python3.7) # get a clean environment
$ grep -R 'import ' . \
    | sed -E 's/.*:\s*//g \
    | sort \
    | uniq \
    > /tmp/imports.py
```
Then I just kept alternating between `python /tmp/imports.py` and `pip install $package` until the `python` command succeeded (I had to remove the `import model` and `import data` lines, since those are local directories, not `pip`-managed packages).  Finally, I ran
```bash
pip freeze
```
to get the full list above.