### PR TITLE
Allow running the get-wikitext2 script from anywhere

### DIFF
--- a/scripts/get-wikitext2
+++ b/scripts/get-wikitext2
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-cd "$(dirname "$(readlink $0)")"
-pwd
+cd "$(dirname "$(realpath $0)")/.."
+
 wikitext2_url=https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip
 
 curl $wikitext2_url > /tmp/wikitext-2.zip


### PR DESCRIPTION
There was an error in the path-normalization before: I was using
`readlink` instead of `realpath`, which had unexpected behavior.
This patch forces the script to `cd` to the parent of the `scripts`
directory before running.

FYI -- I'm not totally sure that `realpath` is a shell command on MacOS.
Let me know if this breaks for you :^)