### PR TITLE
Use `np.exp()` instead of `math.exp`

### DIFF
--- a/model_rnn/main.py
+++ b/model_rnn/main.py
@@ -13,6 +13,7 @@ import torch
 import torch.nn as nn
 import data
 import model
+import numpy as np
 
 try:
     from progress.bar import Bar
@@ -552,7 +553,7 @@ def train():
             print('| epoch {:3d} | {:5d}/{:5d} batches | lr {:02.2f} | ms/batch {:5.2f} | '
                   'loss {:5.2f} | ppl {:8.2f}'.format(
                       epoch, batch, len(train_data) // args.bptt, lr,
-                      elapsed * 1000 / args.log_interval, cur_loss, math.exp(cur_loss)))
+                      elapsed * 1000 / args.log_interval, cur_loss, np.exp(cur_loss)))
             total_loss = 0.
             start_time = time.time()
 


### PR DESCRIPTION
These functions perform the same operation, except that if you try to
exponentiate a huge number using `math.exp`, you'll get an `OverflowError`,
terminating the program.  On the other hand, `np.exp` just returns
`float('inf')` (infinity) if you try this.